### PR TITLE
Update Fedora/Vagrant versions (+ logo URL) in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Locate a vagrant box containing the distribution you want to use at
 initialize.
 
 ```shell
-vagrant init fedora/32-cloud-base
+vagrant init fedora/36-cloud-base
 ```
 
 Then run following command:
@@ -94,7 +94,7 @@ Additionally if you wish to test against a specific version of vagrant you
 can control the version using the following before running the tests:
 
 ```shell
-export VAGRANT_VERSION=v2.2.14
+export VAGRANT_VERSION=v2.2.19
 bundle update && bundle exec rspec --fail-fast --color --format documentation
 ```
 


### PR DESCRIPTION
Fedora version changes every 6 months. So I updated the README to use 36 instead of 32. I like Fedora as well, but you might want to change the example to a longer lived distro like Debian 11 or Alma 9, so you don't have to update it every 6 months. ( debian/bullseye64 or generic/debian11 ) & ( almalinux/9 or generic/alma9 ) ...

I also updated the Vagrant release version. You could also change it to this:

```
export VAGRANT_VERSION=$(curl --silent https://releases.hashicorp.com/vagrant/ | grep -Eo 'href="/vagrant/.*"' | sort --version-sort --reverse | head -1 | sed 's/href\=\"\/vagrant\/\([0-9\.]*\)\/\"/\1/g')
```

And it would find the version automatically. That's what I use in this [script](https://github.com/lavabit/robox/blob/d6b600950c1151f8b9efc586e0f99a0a06a5254a/res/providers/providers.sh).